### PR TITLE
Fix bugs with blog posts on the homepage

### DIFF
--- a/themes/navy/source/js/main.js
+++ b/themes/navy/source/js/main.js
@@ -76,14 +76,14 @@ $(document).ready(function () {
         var storedPosts = store.get('sn_posts'),
             storedTemplate = store.get('sn_template');
 
-        if(typeof storedPosts != 'undefined' && typeof storedTemplate != 'undefined'){
+        if(typeof storedPosts !== 'undefined' && typeof storedTemplate !== 'undefined'){
 
             // Load posts and template from localstorage
             for (const v of storedPosts) {
                 renderPost(v, storedTemplate);
             }
 
-        }else{
+        } else if (allPosts.length) {
 
             var deferred,
                 deferreds = [];

--- a/themes/navy/source/scss/main.scss
+++ b/themes/navy/source/scss/main.scss
@@ -805,6 +805,9 @@ a.active{
                 padding: 0;
                 margin: 0;
                 border: none;
+                img {
+                    width: 100%;
+                }
                 .meta{
                     display: flex;
                     align-items: center;


### PR DESCRIPTION
Bug 1: Duplicated posts -  the`loadGhostPosts` function is called unnecessarily sometimes
<img width="1582" alt="Screen Shot 2020-09-05 at 10 41 25 AM" src="https://user-images.githubusercontent.com/41753422/92294574-b379df00-ef67-11ea-998f-ee94e26c2f9f.png">

Bug 2: Show weird thumbnail images intermittently - CSS didn't work well for some reasons.
<img width="1590" alt="Screen Shot 2020-09-05 at 10 30 09 AM" src="https://user-images.githubusercontent.com/41753422/92294780-e2905080-ef67-11ea-97c3-2eb736cdcd89.png">

Solved these bugs and tested in Chrome, Safari, and Firefox